### PR TITLE
Add primitive keepskills permission

### DIFF
--- a/NewEssentials/Events/UnturnedPlayerDeathEventListener.cs
+++ b/NewEssentials/Events/UnturnedPlayerDeathEventListener.cs
@@ -1,10 +1,17 @@
-﻿using Cysharp.Threading.Tasks;
+﻿using System.Collections.Generic;
+using System.Linq;
+using Cysharp.Threading.Tasks;
 using NewEssentials.Extensions;
 using OpenMod.API.Eventing;
 using OpenMod.API.Users;
 using OpenMod.Core.Users;
 using OpenMod.Unturned.Players.Life.Events;
 using System.Threading.Tasks;
+using NewEssentials.User;
+using OpenMod.API.Permissions;
+using OpenMod.Extensions.Games.Abstractions.Players;
+using OpenMod.Unturned.Users;
+using SDG.Unturned;
 
 namespace NewEssentials.Events
 {
@@ -12,34 +19,46 @@ namespace NewEssentials.Events
     {
         private readonly IUserDataStore m_UserDataStore;
         private readonly IUserDataSeeder m_UserDataSeeder;
+        private readonly IPermissionChecker m_PermissionChecker;
+        private readonly IUserProvider m_UserProvider;
 
-        public UnturnedPlayerDeathEventListener(IUserDataStore userDataStore, IUserDataSeeder userDataSeeder)
+        public UnturnedPlayerDeathEventListener(IUserDataStore userDataStore, IUserDataSeeder userDataSeeder, IPermissionChecker permissionChecker, IUserProvider users)
         {
             m_UserDataStore = userDataStore;
             m_UserDataSeeder = userDataSeeder;
+            m_PermissionChecker = permissionChecker;
+            m_UserProvider = users;
         }
 
         public async Task HandleEventAsync(object sender, UnturnedPlayerDeathEvent @event)
         {
             await UniTask.SwitchToMainThread();
-
+            IUser usr = await m_UserProvider.ToUserAsync(@event.Player);
             var id = @event.Player.EntityInstanceId;
             var position = @event.Player.Transform.Position.ToSerializableVector();
-
+            Dictionary<string, object?> toSeed = new Dictionary<string, object>(){{"deathLocation", position}};
+            if (await m_PermissionChecker.CheckPermissionAsync(usr, "keepskills") ==
+                PermissionGrantResult.Grant)
+            {
+                var skillSet = @event.Player.Player.skills.skills.ToArray();
+                toSeed.Add("skillSet", skillSet);
+            }
             UniTask.RunOnThreadPool(async () =>
             {
                 var userData = await m_UserDataStore.GetUserDataAsync(id, KnownActorTypes.Player);
                 if (userData == null)
                 {
                     var displayName = @event.Player.SteamPlayer.playerID.characterName;
-
+                    
                     await m_UserDataSeeder.SeedUserDataAsync(id, KnownActorTypes.Player, displayName,
-                        new() { { "deathLocation", position } });
+                        toSeed);
 
                     return;
                 }
 
-                userData.Data["deathLocation"] = position;
+                foreach (string k in toSeed.Keys)
+                    userData.Data[k] = toSeed[k];
+                
                 await m_UserDataStore.SetUserDataAsync(userData);
             }).Forget();
         }

--- a/NewEssentials/Events/UnturnedPlayerDeathEventListener.cs
+++ b/NewEssentials/Events/UnturnedPlayerDeathEventListener.cs
@@ -37,7 +37,8 @@ namespace NewEssentials.Events
             var id = @event.Player.EntityInstanceId;
             var position = @event.Player.Transform.Position.ToSerializableVector();
             Dictionary<string, object?> toSeed = new Dictionary<string, object>(){{"deathLocation", position}};
-            if (await m_PermissionChecker.CheckPermissionAsync(usr, "keepskills") ==
+            // ReSharper disable twice CompareOfFloatsByEqualityOperator
+            if (!(Provider.modeConfigData.Players.Lose_Skills_PvE == 1 && Provider.modeConfigData.Players.Lose_Skills_PvP == 1) && await m_PermissionChecker.CheckPermissionAsync(usr, "keepskills") ==
                 PermissionGrantResult.Grant)
             {
                 var skillSet = @event.Player.Player.skills.skills.ToArray();

--- a/NewEssentials/Events/UnturnedPlayerSpawnedEventListener.cs
+++ b/NewEssentials/Events/UnturnedPlayerSpawnedEventListener.cs
@@ -1,0 +1,59 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Reflection;
+using System.Threading.Tasks;
+using Cysharp.Threading.Tasks;
+using NewEssentials.Network;
+using NewEssentials.User;
+using OpenMod.API.Eventing;
+using OpenMod.API.Users;
+using OpenMod.Core.Users;
+using OpenMod.Unturned.Players.Life.Events;
+using SDG.NetPak;
+using SDG.NetTransport;
+using SDG.Unturned;
+
+namespace NewEssentials.Events;
+
+public class UnturnedPlayerSpawnedEventListener : IEventListener<UnturnedPlayerSpawnedEvent>
+{
+    #region Static Reflection
+    private static readonly FieldInfo SkillsInfo;
+
+    static UnturnedPlayerSpawnedEventListener()
+    {
+        SkillsInfo = typeof(PlayerSkills).GetField("_skills", BindingFlags.Instance | BindingFlags.NonPublic);
+    }
+    #endregion
+
+    private readonly IUserDataStore m_UserDataStore;
+
+    public UnturnedPlayerSpawnedEventListener(IUserDataStore userDataStore)
+    {
+        m_UserDataStore = userDataStore;
+    }
+
+    public async Task HandleEventAsync(object sender, UnturnedPlayerSpawnedEvent @event)
+    {
+        await UniTask.SwitchToMainThread();
+        UserData data = await m_UserDataStore.GetUserDataAsync(@event.Player.EntityInstanceId, KnownActorTypes.Player);
+        if (data?.Data == null || !data.Data.ContainsKey("skillSet"))
+            return; //implicitly does not have the permissions or capacity for keep skills
+        Skill[][] skillSet = (Skill[][]) data.Data["skillSet"];
+        SkillsInfo.SetValue(@event.Player.Player.skills.skills, data.Data["skillSet"]);
+        NetworkMethods.SendMultipleSkillLevels.Invoke(@event.Player.Player.skills.GetNetId(),
+            ENetReliability.Reliable,
+            @event.Player.Player.channel.GetOwnerTransportConnection(),
+            writer => WriteSkillLevels(writer, skillSet));
+    }
+    
+    //Reimplementation
+    private static void WriteSkillLevels(NetPakWriter writer, IReadOnlyList<Skill[]> skills)
+    {
+        for (int index = 0; index < skills.Count; ++index)
+        {
+            foreach (Skill skill in skills[index])
+                writer.WriteUInt8(skill.level);
+        }
+    }
+}

--- a/NewEssentials/Events/UnturnedPlayerSpawnedEventListener.cs
+++ b/NewEssentials/Events/UnturnedPlayerSpawnedEventListener.cs
@@ -35,6 +35,10 @@ public class UnturnedPlayerSpawnedEventListener : IEventListener<UnturnedPlayerS
 
     public async Task HandleEventAsync(object sender, UnturnedPlayerSpawnedEvent @event)
     {
+        //shut up resharper
+        // ReSharper disable twice CompareOfFloatsByEqualityOperator
+        if (Provider.modeConfigData.Players.Lose_Skills_PvE == 1 && Provider.modeConfigData.Players.Lose_Skills_PvP == 1)
+            return;
         await UniTask.SwitchToMainThread();
         UserData data = await m_UserDataStore.GetUserDataAsync(@event.Player.EntityInstanceId, KnownActorTypes.Player);
         if (data?.Data == null || !data.Data.ContainsKey("skillSet"))

--- a/NewEssentials/Network/NetworkMethods.cs
+++ b/NewEssentials/Network/NetworkMethods.cs
@@ -1,0 +1,8 @@
+﻿using SDG.Unturned;
+
+namespace NewEssentials.Network;
+
+public static class NetworkMethods
+{
+    public static ClientInstanceMethod SendMultipleSkillLevels { get; } = ClientInstanceMethod.Get(typeof(PlayerSkills), "ReceiveMultipleSkillLevels");
+}

--- a/NewEssentials/NewEssentials.cs
+++ b/NewEssentials/NewEssentials.cs
@@ -68,6 +68,8 @@ namespace NewEssentials
 
             m_PermissionRegistry.RegisterPermission(this, "warps.cooldowns.exempt", "Bypass any warps-related cooldowns", PermissionGrantResult.Deny);
             m_PermissionRegistry.RegisterPermission(this, "kits.cooldowns.exempt", "Bypass any kits-related cooldowns", PermissionGrantResult.Deny);
+            
+            m_PermissionRegistry.RegisterPermission(this, "keepskills", "Keep skills no matter the server configuration", PermissionGrantResult.Deny);
         }
 
         private async Task RegisterDataStores()

--- a/NewEssentials/User/UserExtensions.cs
+++ b/NewEssentials/User/UserExtensions.cs
@@ -1,0 +1,19 @@
+﻿using System;
+using System.Threading.Tasks;
+using OpenMod.API.Users;
+using OpenMod.Core.Users;
+using OpenMod.Unturned.Players;
+
+namespace NewEssentials.User;
+
+public static class UserExtensions
+{
+    public static async Task<IUser> ToUserAsync(this IUserProvider prov, UnturnedPlayer pla)
+    {
+        IUser usr = await prov.FindUserAsync(KnownActorTypes.Player,
+            pla.EntityInstanceId, UserSearchMode.FindById); //? i want to kms
+        if (usr == null)
+            throw new Exception($"Player {pla.SteamPlayer.playerID.playerName} not registered as a user");
+        return usr;
+    }
+}


### PR DESCRIPTION
Stores player skills upon death, then sets them again on player spawn.

Closes #117 